### PR TITLE
Exit with ListenAndServe errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,11 @@ func main() {
 
 	log.Printf("Server starting on port %s", port)
 	go func() {
-		httpServer.ListenAndServe()
+		err := httpServer.ListenAndServe()
+
+		if err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	// Gracefully shutdown when SIGTERM is received


### PR DESCRIPTION
This makes server startup against an already bound port display:
```
2023/01/25 11:03:28 Server starting on port 4008
2023/01/25 11:03:28 listen tcp :4008: bind: address already in use
```

Instead of being indistinguishable from a successful start.
