### PR TITLE
Add configuration option for upstream retries

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -16,6 +17,15 @@ func main() {
 	zipServer := zip_streamer.NewServer()
 	zipServer.Compression = (os.Getenv("ZS_COMPRESSION") == "DEFLATE")
 	zipServer.ListfileUrlPrefix = os.Getenv("ZS_LISTFILE_URL_PREFIX")
+
+	maxUpstreamEntries, exists := os.LookupEnv("ZS_MAX_UPSTREAM_RETRIES")
+	if exists {
+		maxUpstreamRetries, err := strconv.Atoi(maxUpstreamEntries)
+		if err != nil {
+			log.Fatalf("Error parsing ZS_MAX_UPSTREAM_RETRIES: %v", err)
+		}
+		zipServer.MaxUpstreamRetries = maxUpstreamRetries
+	}
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/test/zip_streamer_test.go
+++ b/test/zip_streamer_test.go
@@ -12,6 +12,8 @@ var validFileEntry, _ = zip_streamer.NewFileEntry("https://pbs.twimg.com/media/D
 var validFileEntry2, _ = zip_streamer.NewFileEntry("https://pbs.twimg.com/media/DPRhf4ZX0AAFW1_.jpg", "nested-folder/mona2.jpg")
 var invalidFileEntry, _ = zip_streamer.NewFileEntry("https://pbs.twimg.com/media/fakeURL.jpg", "invalid.jpg")
 
+const maxUpstreamRetries = 0
+
 func TestZipStreamCosntructorEmpty(t *testing.T) {
 	z, err := zip_streamer.NewZipStream(make([]*zip_streamer.FileEntry, 0), ioutil.Discard)
 
@@ -37,7 +39,7 @@ func TestWriteZip(t *testing.T) {
 	if err != nil || z == nil {
 		t.Fatal("constructor failed")
 	}
-	err = z.StreamAllFiles()
+	err = z.StreamAllFiles(maxUpstreamRetries)
 	if err != nil {
 		t.Fatalf("issue writing zip: %v", err)
 	}
@@ -57,7 +59,7 @@ func TestWriteZipWithSomeInvalid(t *testing.T) {
 	if err != nil || z == nil {
 		t.Fatal("constructor failed")
 	}
-	err = z.StreamAllFiles()
+	err = z.StreamAllFiles(maxUpstreamRetries)
 	if err != nil {
 		t.Fatalf("issue writing zip: %v", err)
 	}
@@ -77,7 +79,7 @@ func TestWriteZipWithAllInvalid(t *testing.T) {
 	if err != nil || z == nil {
 		t.Fatal("constructor failed")
 	}
-	err = z.StreamAllFiles()
+	err = z.StreamAllFiles(maxUpstreamRetries)
 	if err == nil {
 		t.Fatalf("empty zip didn't error")
 	}

--- a/zip_streamer/server.go
+++ b/zip_streamer/server.go
@@ -14,10 +14,11 @@ import (
 )
 
 type Server struct {
-	router            *mux.Router
-	linkCache         LinkCache
-	Compression       bool
-	ListfileUrlPrefix string
+	router             *mux.Router
+	linkCache          LinkCache
+	Compression        bool
+	ListfileUrlPrefix  string
+	MaxUpstreamRetries int
 }
 
 func NewServer() *Server {
@@ -152,7 +153,7 @@ func (s *Server) streamEntries(zipDescriptor *ZipDescriptor, w http.ResponseWrit
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", zipDescriptor.EscapedSuggestedFilename()))
 	w.WriteHeader(http.StatusOK)
-	err = zipStreamer.StreamAllFiles()
+	err = zipStreamer.StreamAllFiles(s.MaxUpstreamRetries)
 
 	if err != nil {
 		// Close the connection so the client gets an error instead of 200 but invalid file


### PR DESCRIPTION
Fixes #30.

I figured I would post this before try to write tests since I'm not sure how it should be done. In python-land I would probably mock `retryableGet` to ensure it's getting called. Any suggestions here? Also how do you feel about the backoff approach?